### PR TITLE
Add small fixes for missing auth and missing callback

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -70,6 +70,10 @@ module.exports = {
       decache('../auth/access')
       return require('../auth/access');
     } catch (e) {
+      if (_.isEmpty(process.env.FITBIT_ACCESS_TOKEN) || _.isEmpty(process.env.FITBIT_REFRESH_TOKEN)) {
+        return;
+      }
+
       return {
         accessToken: process.env.FITBIT_ACCESS_TOKEN,
         refreshToken: process.env.FITBIT_REFRESH_TOKEN

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,10 @@ const retrieveMissingData = function (dateFrom, callback) {
 module.exports = function(dateFrom, callback) {
   const completed = function () {
     console.log("Completed");
-    callback();
+
+    if (_.isFunction(callback)) {
+      callback();
+    }
   };
 
   if (_.isEmpty(auth.getAccess())) {


### PR DESCRIPTION
Allow not having environment variable or access file to trigger oauth functionality. Also, remove failure warning when callback is not provided to main app (this support was added in nightly run, but not back ported).